### PR TITLE
fix a bug in password pattern generate function; fix the bug in passo…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ ENV/
 # Rope project settings
 .ropeproject
 .idea/
+.vscode/

--- a/expynent/patterns.py
+++ b/expynent/patterns.py
@@ -186,6 +186,8 @@ USERNAME = r'^[a-zA-Z0-9_.-]{3,16}$'
 # RegEx pattern for matching password.
 PASSWORD = r'^[a-z0-9_-]{6,18}$'
 
+
+
 # RegEx pattern for matching uppercase letters.
 UPPERCASE = r'[A-Z]+$'
 
@@ -235,5 +237,5 @@ def password(mi=6, mx=18):
     :param mx: Maximum length of password.
     :return:
     """
-    pattern = r'/^[a-z0-9_-]{%s,%s}$/' % (mi, mx)
+    pattern = r'(^[a-z0-9_-]{%s,%s}$)' % (mi, mx)
     return pattern

--- a/tests.py
+++ b/tests.py
@@ -65,7 +65,7 @@ class PatternsTestCase(unittest.TestCase):
     def test_password(self):
         pass_pattern = self.patterns.password()
         password = 'some.pa$$w0rd_d'
-        self.assertTrue(pass_pattern, password)
+        self.assertTrue(re.match(pass_pattern, password))
 
     def test_domain_pattern(self):
         domain_pattern = self.patterns.DOMAIN


### PR DESCRIPTION
fix a bug in password pattern generate function:
it should be r'(^[a-z0-9_-]{%s,%s}$)' % (mi, mx).

fix the bug in password test case
it should assert "re.match(pass_pattern, password)"