### PR TITLE
Add pattern to recognize US phone number and cover with tests

### DIFF
--- a/expynent/patterns.py
+++ b/expynent/patterns.py
@@ -276,5 +276,8 @@ PHONE_NUMBER = {
     # RegEx pattern to match French phone numbers (with & without country code)
     'FR': r'^(?:\+33|0)\d{9}$',
     # RegEx pattern to match Indian Phone numbers
-    'IN': r'\d{10}'
+    'IN': r'\d{10}',
+    # Regex pattern to match phone numbers from the United States
+    'US': r'(?P<countrycode>1?)[\s\(-]{0,2}(?P<areadcode>\d{3})[\s\)-]{0,2}'
+          r'(?P<phoneline0>\d{3})[\s-]?(?P<phoneline1>\d{4})'
 }

--- a/tests.py
+++ b/tests.py
@@ -8,6 +8,7 @@ from expynent import (
 
 
 class PatternsTestCase(unittest.TestCase):
+
     def setUp(self):
         self.patterns = patterns
 
@@ -71,8 +72,39 @@ class PatternsTestCase(unittest.TestCase):
         x = '-66.4214188124611'
         self.assertTrue(re.match(latitude_pattern, x))
 
+    def test_us_phone_number_no_seperators(self):
+        num_pattern = self.patterns.PHONE_NUMBER['US']
+        num = '12345678901'
+        self.assertTrue(re.match(num_pattern, num))
+
+    def test_us_phone_number_no_country_code(self):
+        num_pattern = self.patterns.PHONE_NUMBER['US']
+        num = '2345678901'
+        self.assertTrue(re.match(num_pattern, num))
+
+    def test_us_phone_number_mixed_separator(self):
+        num_pattern = self.patterns.PHONE_NUMBER['US']
+        num = '1 (234) 567-8901'
+        self.assertTrue(re.match(num_pattern, num))
+
+    def test_us_phone_number_space_separator(self):
+        num_pattern = self.patterns.PHONE_NUMBER['US']
+        num = '1 234 567 8901'
+        self.assertTrue(re.match(num_pattern, num))
+
+    def test_us_phone_number_dash_separator(self):
+        num_pattern = self.patterns.PHONE_NUMBER['US']
+        num = '1-234-567-8901'
+        self.assertTrue(re.match(num_pattern, num))
+
+    def test_us_phone_number_negative(self):
+        num_pattern = self.patterns.PHONE_NUMBER['US']
+        invalid_num = '-567-8901'
+        self.assertIsNone(re.match(num_pattern, invalid_num))
+
 
 class CompiledPatternsTestCase(unittest.TestCase):
+
     def setUp(self):
         self.compiled_patterns = compiled
 


### PR DESCRIPTION
Hello,
Let me know if you'd like me to make any changes.

It seems like everyone has  been using a one test case per pattern strategy, so I stuck to that. However, I did load up my one test case with multiple asserts. I'd be happy to switch that up if you prefer.

Also, I kept the pattern all on one line because I thought it would be more readable(ish). But I'd be willing to change that as well if you want to adhere to pep8.