### PR TITLE
Added regex for Nicaragua Phone numbers

### DIFF
--- a/expynent/patterns.py
+++ b/expynent/patterns.py
@@ -286,5 +286,7 @@ PHONE_NUMBER = {
     # RegEx pattern to match Spanish phone numbers
     'ES': r'^(?:\+34|0)\d{9}$',
     # RegEx pattern to match Taiwan phone numbers
-    'TW': r'^(?:\+886|0)((?:9\d{8})|(?:[2-8]\d{7,8}))$'
+    'TW': r'^(?:\+886|0)((?:9\d{8})|(?:[2-8]\d{7,8}))$',
+    # RegEx patter to match Nicaragua phone numbers
+    'NI': r'\d{8}'
     }


### PR DESCRIPTION
Nicaragua phone number consist of 8 digits: for example: 8888-8888.