### PR TITLE
Add French license plates pattern

### DIFF
--- a/expynent/patterns.py
+++ b/expynent/patterns.py
@@ -298,7 +298,9 @@ PHONE_NUMBER = {
 # List of RegEx patterns for license plates
 LICENSE_PLATE = {
     # Regex pattern to match Taiwanese license plates
-    'TW': r'(^[A-Z0-9]{2,3}-\d{2,4}$)|(^\d{2,3}-[A-Z0-9]{2,3}$)|(^\d{4}-[A-Z0-9]{2}$)|'
+    'TW': r'(^[A-Z0-9]{2,3}-\d{2,4}$)|(^\d{2,3}-[A-Z0-9]{2,3}$)|(^\d{4}-[A-Z0-9]{2}$)|',
+    # Regex pattern to match French license plates
+    'FR': r'(^[A-Z]{2}-\d{3}-[A-Z]{2}$)|(^\d{1,4}\s[A-Z]{1,3}\s\d{2}$)'
 }
 
 # RegEx pattern for matching 24 hour time format.

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -204,3 +204,47 @@ class PatternsTestCase(unittest.TestCase):
         )
         for num in numerals:
             self.assertTrue(re.match(pattern, num))
+
+    def test_french_license_plates(self):
+        plate_pattern = self.patterns.LICENSE_PLATE['FR']
+        valid_license_plates = (
+            'AA-001-AA',
+            'AA-555-AA',
+            'AA-999-AA',
+            'AA-001-AB',
+            'AA-001-QQ',
+            'AA-999-AZ',
+            'AA-001-BA',
+            'AA-999-ZZ',
+            'AB-001-AA',
+            'AZ-999-ZZ',
+            'BA-001-AA',
+            'ZZ-999-ZZ',
+            '1 A 00',
+            '999 Z 00',
+            '1 AA 00',
+            '999 PZ 00',
+            '1 QA 00',
+            '9999 ZZ 00',
+            '11 AAA 00',
+            '999 ZZZ 00'
+        )
+
+        invalid_license_plates = (
+            'A-011-DC',
+            'DE-23-DE',
+            'DF-532-3D',
+            '1E-123-FD',
+            'A A 00',
+            '999 4 00',
+            '1 AA B0',
+            '9E9 PZ 00',
+            '1 44 00',
+            '9999 ZZ 0G'
+        )
+
+        for plate in valid_license_plates:
+            self.assertTrue(re.match(plate_pattern, plate))
+
+        for plate in invalid_license_plates:
+            self.assertIsNone(re.match(plate_pattern, plate))


### PR DESCRIPTION
I'm not sure of the expected format for the tests:

The tests for the Taiwanese license plates use [one function by plate](https://github.com/lk-geimfari/expynent/blob/master/tests/test_patterns.py#L124-L162) but the ISBN and roman numeral use a [single function](https://github.com/lk-geimfari/expynent/blob/master/tests/test_patterns.py#L180-L206) for several tests cases.

I chose to follow the second option but if that's not the best way I would understand and would gladly rewrote my tests. *(Note that maybe that would be interesting to add this to the contribution guidelines)*