### PR TITLE
Use strict credit card patterns.

### DIFF
--- a/expynent/compiled.py
+++ b/expynent/compiled.py
@@ -2,12 +2,20 @@ import re
 
 import expynent
 
-# RegEx pattern that match credit card number.
+# RegEx pattern that matches a credit card number.
 # Match:
 #    - 3519 2073 7960 3241
 #    - 3519-2073-7960-3241
+#    - 3519 2073-7960 3241
 #    - 3519207379603241
 CREDIT_CARD = re.compile(expynent.CREDIT_CARD)
+
+# RegEx pattern that strictly matches a credit card number.
+# Match:
+#    - 1111-2222-3333-4444
+#    - 1111 2222 3333 4444
+#    - 1111222233334444
+CREDIT_CARD_STRICT = re.compile(expynent.CREDIT_CARD_STRICT)
 
 # RegEx pattern that match slug.
 # Match:

--- a/expynent/patterns.py
+++ b/expynent/patterns.py
@@ -151,7 +151,14 @@ ZIP_CODE = {
 }
 
 # RegEx pattern for matching credit card.
-CREDIT_CARD = '[\d]+((-|\s)?[\d]+)+'
+# This will accept patterns like:
+# XXXXXXXXXXXXXXXX, XXXX-XXXX XXXX-XXXX, XXXX XXXX-XXXX XXXX, 
+# ...or the pattern that CREDIT_CARD_STRICT matches.
+CREDIT_CARD = '^(\d{4}[-\s]?){3}\d{4}$'
+
+# RegEx pattern for matching a credit card that must be in the form of:
+# XXXXXXXXXXXX, XXXX XXXX XXXX XXXX, or XXXX-XXXX-XXXX-XXXX  
+CREDIT_CARD_STRICT = '^((\d{4}){3}|(\d{4}-){3}|(\d{4}\s){3})\d{4}$'
 
 # RegEx pattern for matching email address
 EMAIL_ADDRESS = "([a-z0-9!#$%&'*+\/=?^_`{|.}~-]+@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)"

--- a/tests/test_compiled.py
+++ b/tests/test_compiled.py
@@ -14,15 +14,40 @@ class CompiledPatternsTestCase(unittest.TestCase):
         self.assertTrue(mac_pattern.match(mac))
 
     def test_credit_card_pattern(self):
+        credit_strict_pattern = self.compiled_patterns.CREDIT_CARD_STRICT
+        valid_pats = set((
+            '3519 2073 7960 3241',
+            '3519-2073-7960-3241',
+            '3519207379603241',
+        ))
+        nonstrict_pats = set((
+            '3519-2073 7960 3241',
+            '3519-2073-7960 3241',
+            '3519 2073-7960 3241',
+            '3519 2073-7960-3241',
+            '3519 2073 7960-3241',
+        ))
+        invalid_pats = set((
+            '1234',
+            '123',
+            '12341234123413245',
+            '1234_1234_1234_1234',
+        ))
+        # Test strict pattern.
+        for validpat in valid_pats:
+            self.assertTrue(credit_strict_pattern.match(validpat))
+        # Test non-strict patern.
         credit_pattern = self.compiled_patterns.CREDIT_CARD
-        credit_card = '3519 2073 7960 3241'
-        self.assertTrue(credit_pattern.match(credit_card))
+        for validpat in valid_pats.union(nonstrict_pats):
+            self.assertTrue(credit_pattern.match(validpat))
 
-        credit_card = '3519-2073-7960-3241'
-        self.assertTrue(credit_pattern.match(credit_card))
+        # Test invalid patterns for strict.
+        for invalidpat in invalid_pats.union(nonstrict_pats):
+            self.assertFalse(credit_strict_pattern.match(invalidpat))
 
-        credit_card = '3519207379603241'
-        self.assertTrue(credit_pattern.match(credit_card))
+        # Test invalid patterns for non-strict.
+        for invalidpat in invalid_pats:
+            self.assertFalse(credit_pattern.match(invalidpat))
 
     def test_ip_v4_pattern(self):
         ip_v4_pattern = self.compiled_patterns.IP_V4

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -22,15 +22,40 @@ class PatternsTestCase(unittest.TestCase):
         self.assertTrue(re.match(mac_pattern, mac))
 
     def test_credit_card_pattern(self):
+        credit_strict_pattern = self.patterns.CREDIT_CARD_STRICT
+        valid_pats = set((
+            '3519 2073 7960 3241',
+            '3519-2073-7960-3241',
+            '3519207379603241',
+        ))
+        nonstrict_pats = set((
+            '3519-2073 7960 3241',
+            '3519-2073-7960 3241',
+            '3519 2073-7960 3241',
+            '3519 2073-7960-3241',
+            '3519 2073 7960-3241',
+        ))
+        invalid_pats = set((
+            '1234',
+            '123',
+            '12341234123413245',
+            '1234_1234_1234_1234',
+        ))
+        # Test strict pattern.
+        for validpat in valid_pats:
+            self.assertTrue(re.match(credit_strict_pattern, validpat))
+        # Test non-strict patern.
         credit_pattern = self.patterns.CREDIT_CARD
-        credit_card = '3519 2073 7960 3241'
-        self.assertTrue(re.match(credit_pattern, credit_card))
+        for validpat in valid_pats.union(nonstrict_pats):
+            self.assertTrue(re.match(credit_pattern, validpat))
 
-        credit_card = '3519-2073-7960-3241'
-        self.assertTrue(re.match(credit_pattern, credit_card))
+        # Test invalid patterns for strict.
+        for invalidpat in invalid_pats.union(nonstrict_pats):
+            self.assertFalse(re.match(credit_strict_pattern, invalidpat))
 
-        credit_card = '3519207379603241'
-        self.assertTrue(re.match(credit_pattern, credit_card))
+        # Test invalid patterns for non-strict.
+        for invalidpat in invalid_pats:
+            self.assertFalse(re.match(credit_pattern, invalidpat))
 
     def test_ip_v4_pattern(self):
         ip_v4_pattern = self.patterns.IP_V4


### PR DESCRIPTION
Use strict credit card patterns.

`CREDIT_CARD` matches 16 digits, grouped by four with an optional
space or hyphen. The spaces/hyphens can be mixed:

* `XXXXXXXXXXXXXXXX`
* `XXXX-XXXX-XXXX-XXXX`
* `XXXX XXXX XXXX XXXX`
* `XXXX-XXXX XXXX-XXXX`
* `XXXX XXXX-XXXX XXXX`

`CREDIT_CARD_STRICT` matches 16 digits, grouped by four with an
optional space or hyphen. The spaces/hyphens cannot be mixed:

* `XXXXXXXXXXXXXXXX`
* `XXXX-XXXX-XXXX-XXXX`
* `XXXX XXXX XXXX XXXX`

Tests were added for both patterns.
