### PR TITLE
Add utf-8 source code encoding to patterns

### DIFF
--- a/expynent/patterns.py
+++ b/expynent/patterns.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # RegEx pattern for matching zip code.
 # Using:
 #     - us_zip = ZIP_CODE['US']


### PR DESCRIPTION
This fixes the following python2.7 build error:

$ python2.7 setup.py build
Traceback (most recent call last):
  File "setup.py", line 1, in <module>
    import expynent
  File "/var/opt/git/hub/upstream/expynent/expynent/__init__.py", line 7, in <module>
    from .patterns import *
  File "/var/opt/git/hub/upstream/expynent/expynent/patterns.py", line 325
SyntaxError: Non-ASCII character '\xce' in file /var/opt/wim/git/hub/upstream/expynent/expynent/patterns.py on line 325, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details